### PR TITLE
Replace deprecated Guzzle Utils::jsonDecode()

### DIFF
--- a/src/ReCaptcha.php
+++ b/src/ReCaptcha.php
@@ -5,7 +5,6 @@ namespace Drupal\wmrecaptcha;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Utils;
 
 class ReCaptcha
 {
@@ -79,7 +78,11 @@ class ReCaptcha
         }
 
         $body = $response->getBody()->getContents();
-        $body = Utils::jsonDecode($body, true);
+        // Guzzle's Utils::jsonDecode() is deprecated and is removed in
+        // guzzlehttp/guzzle:8.0. JSON_THROW_ON_ERROR keeps the existing
+        // behaviour of throwing on a malformed response body (Guzzle threw an
+        // InvalidArgumentException; this throws a JsonException).
+        $body = json_decode($body, true, 512, \JSON_THROW_ON_ERROR);
 
         return $body['success'];
     }


### PR DESCRIPTION
`GuzzleHttp\Utils::jsonDecode()` is deprecated and **removed in guzzlehttp/guzzle:8.0**, which is now released. Any consuming project that moves to Guzzle 8 gets a fatal in `ReCaptcha::verify()`.

## Change

`Utils::jsonDecode($body, true)` → `json_decode($body, true, 512, JSON_THROW_ON_ERROR)`.

`JSON_THROW_ON_ERROR` is deliberate: without it `json_decode()` returns `null` on a malformed body and the following `$body['success']` would degrade into a null-index warning plus a `TypeError`. With it, the semantics match what Guzzle did — throw on unparseable input. The only observable difference is the exception class (`InvalidArgumentException` → `JsonException`); neither is caught here, since the existing `try/catch` only wraps the HTTP call.

## Pre-existing issue, deliberately left alone

`verify()` is declared `: bool` but returns `$body['success']` unguarded. A 200 response whose body is valid JSON *without* a `success` key still raises a `TypeError`. For a captcha check, failing closed (`return false`) on an unparseable or unexpected verification response would be safer — but that is a behaviour change in a security-relevant path, so it belongs in its own commit rather than being smuggled into a deprecation fix. Flagging it for you to decide.

## Compatibility

Works unchanged on Guzzle 7 and 8, so no version gating is needed. No core-version dependency.

## How it was found

`drupal/upgrade_status` 5.0.0-alpha3 scan while verifying www.uzleuven.be on Drupal 11.4.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)